### PR TITLE
Collect and report decision points in example dextool plugin

### DIFF
--- a/plugin/example/source/dextool/plugin/example/runner.d
+++ b/plugin/example/source/dextool/plugin/example/runner.d
@@ -54,7 +54,7 @@ ExitStatusType runPlugin(string[] args) {
         return ExitStatusType.Errors;
     }
 
-    writeln("Run the plugin -d to see the AST");
+    writeln("Run the plugin to print decisions found in the input file");
 
     import dextool.utility : prependDefaultFlags, PreferLang;
 
@@ -71,6 +71,7 @@ ExitStatusType runPlugin(string[] args) {
     auto exit_status = analyzeFile(AbsolutePath(Path(pargs.file)), cflags, visitor, ctx);
 
     if (exit_status == ExitStatusType.Ok) {
+        visitor.printDecisions;
         writeln(visitor.generatedCode.render);
     }
 
@@ -144,6 +145,7 @@ override void visit(const WhileStmt) {...}
 */
 final class TUVisitor : Visitor {
     import libclang_ast.ast;
+    import clang.Cursor : Cursor;
     import cpptooling.data.symbol : Container;
     import libclang_ast.cursor_logger : logNode, mixinNodeLog;
     import dsrcgen.cpp;
@@ -155,6 +157,39 @@ final class TUVisitor : Visitor {
     CppHModule generatedCode;
     private CppModule generatedFunctions;
     private Container container;
+    private string[] decisions;
+    private bool[string] decisionDedup;
+
+    private void collectDecision(string kind, scope const Cursor c) {
+        import std.algorithm : map;
+        import std.array : array;
+        import std.format : format;
+        import std.string : join;
+
+        const tokens = c.tokens.map!(a => a.spelling).array;
+        const expr = tokens.length ? tokens.join(" ") : c.spelling;
+        const loc = c.location;
+
+        const entry = format("%s at %s:%s:%s -> %s", kind, loc.file, loc.line,
+                loc.column, expr);
+        if (entry !in decisionDedup) {
+            decisions ~= entry;
+            decisionDedup[entry] = true;
+        }
+    }
+
+    void printDecisions() {
+        import std.stdio : writeln;
+
+        writeln("Decisions:");
+        if (decisions.length == 0) {
+            writeln("  none found");
+        } else {
+            foreach (d; decisions) {
+                writeln("  ", d);
+            }
+        }
+    }
 
     this() {
         this.generatedCode = CppHModule("a_ifdef_guard");
@@ -216,6 +251,25 @@ final class TUVisitor : Visitor {
         v.accept(this);
     }
 
+    override void visit(scope const BinaryOperator v) {
+        mixin(mixinNodeLog!());
+        import std.algorithm : canFind, map;
+        import std.array : array;
+
+        const tokens = v.cursor.tokens.map!(a => a.spelling).array;
+        if (tokens.canFind("&&") || tokens.canFind("||")) {
+            collectDecision("logical expression", v.cursor);
+        }
+
+        v.accept(this);
+    }
+
+    override void visit(scope const ConditionalOperator v) {
+        mixin(mixinNodeLog!());
+        collectDecision("ternary decision", v.cursor);
+        v.accept(this);
+    }
+
     override void visit(scope const Preprocessor v) {
         mixin(mixinNodeLog!());
         v.accept(this);
@@ -228,6 +282,36 @@ final class TUVisitor : Visitor {
 
     override void visit(scope const Statement v) {
         mixin(mixinNodeLog!());
+        v.accept(this);
+    }
+
+    override void visit(scope const IfStmt v) {
+        mixin(mixinNodeLog!());
+        collectDecision("if decision", v.cursor);
+        v.accept(this);
+    }
+
+    override void visit(scope const WhileStmt v) {
+        mixin(mixinNodeLog!());
+        collectDecision("while decision", v.cursor);
+        v.accept(this);
+    }
+
+    override void visit(scope const DoStmt v) {
+        mixin(mixinNodeLog!());
+        collectDecision("do-while decision", v.cursor);
+        v.accept(this);
+    }
+
+    override void visit(scope const ForStmt v) {
+        mixin(mixinNodeLog!());
+        collectDecision("for decision", v.cursor);
+        v.accept(this);
+    }
+
+    override void visit(scope const SwitchStmt v) {
+        mixin(mixinNodeLog!());
+        collectDecision("switch decision", v.cursor);
         v.accept(this);
     }
 }

--- a/plugin/example/source/dextool/plugin/example/runner.d
+++ b/plugin/example/source/dextool/plugin/example/runner.d
@@ -160,7 +160,15 @@ final class TUVisitor : Visitor {
     private string[] decisions;
     private bool[string] decisionDedup;
 
-    private void collectDecision(string kind, scope const Cursor c) {
+    private bool hasLogicalOperator(scope const Cursor c) @trusted {
+        import std.algorithm : canFind, map;
+        import std.array : array;
+
+        const tokens = c.tokens.map!(a => a.spelling).array;
+        return tokens.canFind("&&") || tokens.canFind("||");
+    }
+
+    private void collectDecision(string kind, scope const Cursor c) @trusted {
         import std.algorithm : map;
         import std.array : array;
         import std.format : format;
@@ -253,11 +261,7 @@ final class TUVisitor : Visitor {
 
     override void visit(scope const BinaryOperator v) {
         mixin(mixinNodeLog!());
-        import std.algorithm : canFind, map;
-        import std.array : array;
-
-        const tokens = v.cursor.tokens.map!(a => a.spelling).array;
-        if (tokens.canFind("&&") || tokens.canFind("||")) {
+        if (hasLogicalOperator(v.cursor)) {
             collectDecision("logical expression", v.cursor);
         }
 


### PR DESCRIPTION
### Motivation
- Enhance the example plugin to identify and report control-flow decision points (ifs, loops, switch, ternary and logical expressions) discovered in parsed source files.
- Provide a concise user-facing message and a way to print the collected decisions after analysis.

### Description
- Replaced the startup message with a description that the plugin will "print decisions found in the input file" and call `visitor.printDecisions` on successful analysis.
- Added `decisions` storage and a `decisionDedup` map to deduplicate entries, and implemented `collectDecision` to format and stash decision entries (using cursor tokens and source locations).
- Implemented `printDecisions` to print a human-readable list of discovered decisions.
- Added visitor overrides for `BinaryOperator`, `ConditionalOperator`, `IfStmt`, `WhileStmt`, `DoStmt`, `ForStmt`, and `SwitchStmt` to call `collectDecision` (with `BinaryOperator` detecting `&&`/`||`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c931235de48322b514633bb80029d8)